### PR TITLE
Improve student activity registration system

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -19,7 +19,7 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
+# In-memory activity database 
 activities = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Competitive soccer team practicing skills and playing matches",
+        "schedule": "Mondays, Wednesdays, Fridays, 4:00 PM - 6:00 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Pickup games and coached practice to develop team play",
+        "schedule": "Tuesdays and Thursdays, 5:00 PM - 7:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "jack@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore drawing, painting, and mixed media projects",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["isabella@mergington.edu", "mia@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting, stagecraft, and production for school performances",
+        "schedule": "Thursdays, 4:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": ["charlotte@mergington.edu", "amelia@mergington.edu"]
+    },
+    "Robotics Club": {
+        "description": "Design, build, and program robots for competitions and learning",
+        "schedule": "Tuesdays and Fridays, 4:00 PM - 6:00 PM",
+        "max_participants": 16,
+        "participants": ["lucas@mergington.edu", "ethan@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Practice persuasive speaking and compete in debate tournaments",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["oliver@mergington.edu", "grace@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -7,7 +7,7 @@ for extracurricular activities at Mergington High School.
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, JSONResponse
 import os
 from pathlib import Path
 
@@ -85,7 +85,8 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    # Disable caching so clients always see the latest participants
+    return JSONResponse(content=activities, headers={"Cache-Control": "no-store"})
 
 
 @app.post("/activities/{activity_name}/signup")
@@ -105,3 +106,21 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    # Validate student is actually signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not registered for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -18,11 +18,16 @@ document.addEventListener("DOMContentLoaded", () => {
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", {
+        cache: "no-store",
+        headers: { "Cache-Control": "no-cache" },
+      });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      // Reset the dropdown to avoid duplicate options on refresh
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -34,7 +39,22 @@ document.addEventListener("DOMContentLoaded", () => {
         // Build participants section (bulleted list or empty state)
         const participants = Array.isArray(details.participants) ? details.participants : [];
         const participantsList = participants.length
-          ? `<ul class="participants-list">${participants.map(p => `<li>${escapeHtml(String(p))}</li>`).join("")}</ul>`
+          ? `<ul class="participants-list">${participants
+              .map(
+                (p) => `
+                <li class="participant-item">
+                  <span class="participant-email">${escapeHtml(String(p))}</span>
+                  <button
+                    class="delete-participant"
+                    title="Unregister"
+                    aria-label="Unregister ${escapeHtml(String(p))} from ${escapeHtml(name)}"
+                    data-activity="${escapeHtml(name)}"
+                    data-email="${escapeHtml(String(p))}"
+                  >✖</button>
+                </li>`
+              )
+              .join("")}
+            </ul>`
           : `<p class="participants-empty">No participants yet — be the first to sign up!</p>`;
 
         activityCard.innerHTML = `
@@ -106,4 +126,47 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Initialize app
   fetchActivities();
+
+  // Handle click on delete buttons using event delegation
+  activitiesList.addEventListener("click", async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    if (!target.classList.contains("delete-participant")) return;
+
+    const activity = target.getAttribute("data-activity");
+    const email = target.getAttribute("data-email");
+    if (!activity || !email) return;
+
+    // Optional confirmation
+    const confirmed = confirm(`Unregister ${email} from ${activity}?`);
+    if (!confirmed) return;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+        { method: "DELETE" }
+      );
+      const result = await response.json();
+      if (response.ok) {
+        messageDiv.textContent = result.message || "Participant removed";
+        messageDiv.className = "success";
+        messageDiv.classList.remove("hidden");
+        // Refresh activities to reflect updated list and availability
+        fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "Failed to unregister participant";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+      }
+
+      // Hide message after 5 seconds
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+    } catch (err) {
+      console.error("Error unregistering participant:", err);
+      messageDiv.textContent = "Failed to unregister. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+    }
+  });
 });

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,17 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Escape HTML to prevent injection in rendered content
+  function escapeHtml(str) {
+    if (typeof str !== "string") return str;
+    return str
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -20,11 +31,21 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        // Build participants section (bulleted list or empty state)
+        const participants = Array.isArray(details.participants) ? details.participants : [];
+        const participantsList = participants.length
+          ? `<ul class="participants-list">${participants.map(p => `<li>${escapeHtml(String(p))}</li>`).join("")}</ul>`
+          : `<p class="participants-empty">No participants yet — be the first to sign up!</p>`;
+
         activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
+          <h4>${escapeHtml(name)}</h4>
+          <p>${escapeHtml(details.description)}</p>
+          <p><strong>Schedule:</strong> ${escapeHtml(details.schedule)}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants">
+            <h5 class="participants-title">Participants</h5>
+            ${participantsList}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +83,8 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // Refresh the list to show updated participants and availability
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,34 @@ section h3 {
   margin-bottom: 8px;
 }
 
+/* Participants section styles */
+.activity-card .participants {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed #ddd;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #1a237e;
+  font-size: 0.95rem;
+  letter-spacing: 0.2px;
+}
+
+.participants-list {
+  margin-left: 20px; /* keeps bullets visible */
+  line-height: 1.5;
+}
+
+.participants-list li {
+  margin: 4px 0;
+}
+
+.participants-empty {
+  color: #666;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -89,12 +89,40 @@ section h3 {
 }
 
 .participants-list {
-  margin-left: 20px; /* keeps bullets visible */
+  list-style: none; /* hide bullets */
+  margin: 0;
+  padding-left: 0;
   line-height: 1.5;
 }
 
-.participants-list li {
-  margin: 4px 0;
+.participants-list .participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 6px 0;
+}
+
+.participant-email {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.delete-participant {
+  background: transparent;
+  color: #c62828;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 2px 6px;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.delete-participant:hover,
+.delete-participant:focus {
+  background: #ffebee;
+  border-color: #ef9a9a;
 }
 
 .participants-empty {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,93 @@
+import copy
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import app, activities as app_activities
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Backup and restore in-memory activities between tests to avoid cross-test pollution."""
+    backup = copy.deepcopy(app_activities)
+    try:
+        yield
+    finally:
+        app_activities.clear()
+        app_activities.update(copy.deepcopy(backup))
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
+
+
+def test_get_activities_returns_expected_structure(client):
+    resp = client.get("/activities")
+    assert resp.status_code == 200
+    data = resp.json()
+    # Has several known activities
+    assert isinstance(data, dict)
+    assert "Chess Club" in data
+    assert "Programming Class" in data
+    # Each activity has required fields
+    for details in data.values():
+        assert set(["description", "schedule", "max_participants", "participants"]).issubset(details.keys())
+
+
+def test_signup_success_and_reflected_in_listing(client):
+    activity = "Gym Class"
+    email = "newstudent@mergington.edu"
+
+    # Ensure not present initially
+    before = client.get("/activities").json()[activity]["participants"]
+    assert email not in before
+
+    # Sign up
+    resp = client.post(f"/activities/{activity}/signup", params={"email": email})
+    assert resp.status_code == 200
+    assert "Signed up" in resp.json()["message"]
+
+    # Now present
+    after = client.get("/activities").json()[activity]["participants"]
+    assert email in after
+
+
+def test_signup_duplicate_is_rejected(client):
+    activity = "Programming Class"
+    existing_email = "emma@mergington.edu"  # already registered in seed data
+
+    resp = client.post(f"/activities/{activity}/signup", params={"email": existing_email})
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Student is already signed up"
+
+
+def test_unregister_success_then_cannot_unregister_twice(client):
+    activity = "Art Club"
+    email = "isabella@mergington.edu"  # present in seed data
+
+    # Unregister succeeds first time
+    resp = client.delete(f"/activities/{activity}/unregister", params={"email": email})
+    assert resp.status_code == 200
+    assert "Unregistered" in resp.json()["message"]
+
+    # No longer in list
+    participants = client.get("/activities").json()[activity]["participants"]
+    assert email not in participants
+
+    # Second attempt should be rejected
+    resp2 = client.delete(f"/activities/{activity}/unregister", params={"email": email})
+    assert resp2.status_code == 400
+    assert resp2.json()["detail"] == "Student is not registered for this activity"
+
+
+def test_activity_not_found_404(client):
+    missing = "Underwater Basket Weaving"
+    email = "nobody@mergington.edu"
+
+    r1 = client.post(f"/activities/{missing}/signup", params={"email": email})
+    assert r1.status_code == 404
+    assert r1.json()["detail"] == "Activity not found"
+
+    r2 = client.delete(f"/activities/{missing}/unregister", params={"email": email})
+    assert r2.status_code == 404
+    assert r2.json()["detail"] == "Activity not found"


### PR DESCRIPTION
This pull request adds several new features and improvements to the school activities signup app, focusing on participant management, frontend usability, and backend reliability. The most important changes include adding support for unregistering participants, displaying and managing participants in the frontend, improving cache handling, and introducing automated tests for the backend API.

**Backend features and API improvements:**

* Added a new `DELETE /activities/{activity_name}/unregister` endpoint to allow students to unregister from activities, with validation to prevent duplicate or invalid operations.
* Updated the `GET /activities` endpoint to return a `JSONResponse` with `Cache-Control: no-store` headers, ensuring clients always see the latest participant information.
* Added validation to the signup endpoint to prevent duplicate registrations for the same activity.
* Seeded additional activities with sample participants to support richer frontend display and testing.

**Frontend enhancements:**

* Displayed a bulleted list of participants for each activity, including a delete button for each participant to allow unregistering via the frontend. All displayed content is now HTML-escaped to prevent injection vulnerabilities.
* Implemented event delegation to handle participant removal: clicking the delete button triggers an API request to unregister the participant and refreshes the activity list.
* Ensured frontend fetches always bypass cache and reset dropdown options to avoid duplication. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R7-R30) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R106-R107)
* Added new CSS styles for the participants section, including layout, button styling, and empty state messaging.

**Testing and reliability:**

* Introduced a comprehensive test suite using pytest and FastAPI's TestClient, covering activity listing, signup, duplicate signup rejection, unregistering, and error handling for missing activities. Tests include state reset to avoid cross-test pollution.
* Added `.vscode/settings.json` to configure pytest as the default test runner for development.